### PR TITLE
hx711.py: optimization of code & some enhancements

### DIFF
--- a/hx711.py
+++ b/hx711.py
@@ -1,28 +1,20 @@
-from machine import Pin
+from machine import Pin, enable_irq, disable_irq, idle
 
 class HX711:
     def __init__(self, dout, pd_sck, gain=128):
-        
+
         self.pSCK = Pin(pd_sck , mode=Pin.OUT)
         self.pOUT = Pin(dout, mode=Pin.IN, pull=Pin.PULL_DOWN)
+        self.pSCK.value(False)
 
         self.GAIN = 0
         self.OFFSET = 0
         self.SCALE = 1
-        self.lastVal = 0
-        self.allTrue = False
         
-        self.set_gain(gain);
-        
+        self.time_constant = 0.1
+        self.filtered = 0
 
-    def createBoolList(size=8):
-        ret = []
-        for i in range(8):
-            ret.append(False)
-        return ret
-    
-    def is_ready(self):
-        return self.pOUT() == 0
+        self.set_gain(gain);
 
     def set_gain(self, gain):
         if gain is 128:
@@ -32,68 +24,45 @@ class HX711:
         elif gain is 32:
             self.GAIN = 2
 
-        self.pSCK.value(False)
         self.read()
-        print('Gain setted')
+        self.filtered = self.read()
+        print('Gain & initial value set')
+    
+    def is_ready(self):
+        return self.pOUT() == 0
 
     def read(self):
-        
-        dataBits = [self.createBoolList(), self.createBoolList(), self.createBoolList()]
-        while not self.is_ready():
-            pass
-              
-        for j in range(2, -1, -1):
-            for i in range(7, -1, -1):
-                self.pSCK.value(True)
-                dataBits[j][i] = self.pOUT()
-                self.pSCK.value(False)
+        # wait for the device being ready
+        while self.pOUT() == 1:
+            idle()
 
+        # shift in data, and gain & channel info
+        result = 0
+        for j in range(24 + self.GAIN):
+            state = disable_irq()
+            self.pSCK(True)
+            self.pSCK(False)
+            enable_irq(state)
+            result = (result << 1) | self.pOUT()
 
-        #set channel and gain factor for next reading
-        for i in range(self.GAIN):
-            self.pSCK.value(True)
-            self.pSCK.value(False)
-            
+        # shift back the extra bits
+        result >>= self.GAIN
 
-        #check for all 1
-        if all(item == True for item in dataBits[0]):
-            print('all true')
-            self.allTrue=True
-            return self.lastVal
+        # check sign
+        if result > 0x7fffff:
+            result -= 0x1000000
 
-        self.allTrue=False
-
-        
-        readbits = ""
-        for j in range(2, -1, -1):
-            for i in range(7, -1, -1):
-                if dataBits[j][i] == True:
-                    readbits= readbits +'1'
-                else:
-                    readbits= readbits+'0'
-
-        self.lastVal = int(readbits, 2)
-        
-        if self.lastVal > 0x7fffff:
-            self.lastVal -= 0x1000000
-
-        return self.lastVal
-
-
+        return result
 
     def read_average(self, times=3):
         sum = 0
-        effectiveTimes = 0
-        readed = 0
         for i in range(times):
-            readed = self.read()
-            if self.allTrue == False:
-                sum += readed
-                effectiveTimes+=1
+            sum += self.read()
+        return sum / times
 
-        if effectiveTimes == 0:
-            return 0
-        return sum / effectiveTimes
+    def read_lowpass(self):
+        self.filtered += self.time_constant * (self.read() - self.filtered)
+        return self.filtered
 
     def get_value(self, times=3):
         return self.read_average(times) - self.OFFSET
@@ -111,11 +80,15 @@ class HX711:
     def set_offset(self, offset):
         self.OFFSET = offset
 
+    def set_time_constant(self, time_constant = None):
+        if time_constant is None:
+            return self.time_constant
+        elif 0 < time_constant < 1.0:
+            self.time_constant = time_constant
+
     def power_down(self):
         self.pSCK.value(False)
         self.pSCK.value(True)
 
-
     def power_up(self):
         self.pSCK.value(False)
-


### PR DESCRIPTION
1. Optimization of the read() method.

The core loop is optimized and the data bits are directly
collected into the result value. And interrupts are disabled
during the high phase of the clock pulse. That ensures that
the positive clock pulse is never longer than 50 µs.
Then, all code related to the alltrue state is obsolete, and
was removed.

2. Adding a lowpass filtered read method.

That consists of the methods read_lowpass() and set_time_constant().
read_lowpass() is somewhat comparable to a sliding average, but returns
a value at the rate of the underlying read() call. The time constant
for the filter is set with set_time_constant. The range is 0 to 1.
1 is equivalent to no filter at all, 0 means inifinite time constant.
Reasonable values are 0.01 to 0.75.